### PR TITLE
Config timezone in Docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,10 @@ FROM node:${NODE_VERSION}-alpine AS runner_image
 
 WORKDIR /usr/src/app
 
+RUN apk add --no-cache tzdata && \
+    cp /usr/share/zoneinfo/Europe/Rome /etc/localtime && \
+    echo "Europe/Rome" > /etc/timezone
+
 COPY --from=build_image /usr/src/app/node_modules ./node_modules
 ADD . .
 ADD package*.json ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,8 @@ FROM node:${NODE_VERSION}-alpine AS runner_image
 WORKDIR /usr/src/app
 
 RUN apk add --no-cache tzdata && \
-    cp /usr/share/zoneinfo/Europe/Rome /etc/localtime && \
-    echo "Europe/Rome" > /etc/timezone
+    cp /usr/share/zoneinfo/UTC /etc/localtime && \
+    echo "UTC" > /etc/timezone
 
 COPY --from=build_image /usr/src/app/node_modules ./node_modules
 ADD . .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,4 +2,6 @@ services:
   actual_task:
     build: .
     env_file: .env
+    environment:
+      - TZ=Europe/Rome
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,5 +3,5 @@ services:
     build: .
     env_file: .env
     environment:
-      - TZ=Europe/Rome
+      - TZ=UTC
     restart: unless-stopped


### PR DESCRIPTION
This PR adds the `tzdata` package to the Dockerfile and sets the default timezone to UTC in both the container and the `docker-compose.yml` environment variables with possibility to change for users.